### PR TITLE
various minor fixes across all examples

### DIFF
--- a/binary-search/Binary_Search.org
+++ b/binary-search/Binary_Search.org
@@ -8,7 +8,7 @@ The ~Binary_Search~ algorithm is a classic Computer Science
 algorithm. Its signature can be expressed as
 
 #+BEGIN_SRC ada
-  function Binary_Search (A : T_Arr; Val : T) return Boolean
+  function Binary_Search (A : T_Arr; Val : T) return Boolean;
 #+END_SRC
 
 It will simply return ~True~ if ~Val~ is contained in ~A~.
@@ -54,7 +54,7 @@ The implementation of ~Binary_Search~ is
      else
         return False;
      end if;
-  
+
   end Binary_Search;
 #+END_SRC
 

--- a/binary-search/Search_Equal_Range.org
+++ b/binary-search/Search_Equal_Range.org
@@ -10,7 +10,7 @@ value ~V~ in a given array ~A~.
 Its signature can be expressed as :
 
 #+BEGIN_SRC ada
-  function Search_Equal_Range (A : T_Arr; V : T) return Option_Pair
+  function Search_Equal_Range (A : T_Arr; V : T) return Option_Pair;
 #+END_SRC
 
 This function returns an ~Option_Pair~. ~Option_Pair~ is just a
@@ -91,7 +91,7 @@ The postconditions are expressed through contract cases stating that
               = V~
   4. for all ~J~ in ~Result.Upper .. A'Last~ then ~V < A(J)~
 
-  Again, the ranges defined for $J$ may be empty.
+  Again, the ranges defined for ~J~ may be empty.
 
 ** Implementations of Search_Equal_Range
 
@@ -111,20 +111,20 @@ indexes:
      V : T)
      return Option_Pair
   is
-  
+
      Result : Option_Pair := (Exists => False);
   begin
-  
+
      if A'Length > 0 then
         Result :=
   	(Exists => True, Lower => Search_Lower_Bound (A, V).Value,
   	 Upper  => Search_Upper_Bound (A, V).Value);
-  
+
      else
         null;
-  
+
      end if;
-  
+
      return Result;
   end Search_Equal_Range;
 #+END_SRC
@@ -147,7 +147,7 @@ which in SPARK translates to:
      V : T)
      return Option_Pair
   is
-  
+
      Result : Option_Pair := (Exists => False);
      Middle : Integer     := A'First;
      Left   : Integer     := A'First;
@@ -157,7 +157,7 @@ which in SPARK translates to:
         Result := (Exists => True, Lower => A'First, Upper => A'Last + 1);
         while Right > Left loop
   	 Middle := Left + (Right - Left) / 2;
-  
+
   	 if A (Middle) < V then
   	    Left := Middle + 1;
   	 elsif V < A (Middle) then
@@ -165,7 +165,7 @@ which in SPARK translates to:
   	 else
   	    exit;
   	 end if;
-  
+
   	 pragma Loop_Variant (Decreases => Right - Left);
   	 pragma Loop_Invariant
   	   (A'First <= Left and then Left <= Right
@@ -176,32 +176,32 @@ which in SPARK translates to:
   	 pragma Loop_Invariant
   	   (if Right /= A'Last + 1 then
   	      Strict_Lower_Bound (A (Right .. A'Last), V));
-  
+
         end loop;
-  
+
         if Left < Right then
-  
+
   	 Result.Lower := Search_Lower_Bound (A (Left .. Middle), V).Value;
-  
+
   	 Middle := Middle + 1;
-  
+
   	 if Middle < A'Last + 1 then
   	    Result.Upper :=
   	      Search_Upper_Bound (A (Middle .. A'Last), V).Value;
   	 else
   	    Result.Upper := A'Last + 1;
   	 end if;
-  
+
         else
   	 Result.Lower := Left;
   	 Result.Upper := Right;
-  
+
         end if;
-  
+
      end if;
-  
+
      return Result;
-  
+
   end Search_Equal_Range_Opt;
 #+END_SRC
 

--- a/binary-search/Search_Lower_Bound.org
+++ b/binary-search/Search_Lower_Bound.org
@@ -9,7 +9,7 @@ which a value can be found in a sorted array. Its signature can be
 expressed as:
 
 #+BEGIN_SRC ada
-  function Search_Lower_Bound (A : T_arr; V : T) return Option
+  function Search_Lower_Bound (A : T_arr; V : T) return Option;
 #+END_SRC
 
 ** Working principle
@@ -78,17 +78,17 @@ The implementation of ~Search_Lower_Bound~ is defined as follows:
      V : T)
      return Option
   is
-  
+
      Result : Option  := (Exists => False);
      Right  : Integer := A'Last + 1;
      Middle : Integer := A'Last + 1;
   begin
-  
+
      if A'Length = 0 then
         return Result;
      else
         Result := (Exists => True, Value => A'First);
-  
+
         while Result.Value < Right loop
   	 Middle := Result.Value + (Right - Result.Value) / 2;
   	 if A (Middle) < V then
@@ -96,7 +96,7 @@ The implementation of ~Search_Lower_Bound~ is defined as follows:
   	 else
   	    Right := Middle;
   	 end if;
-  
+
   	 pragma Loop_Variant (Decreases => Right - Result.Value);
   	 pragma Loop_Invariant
   	   (A'First <= Result.Value and then Result.Value <= Right
@@ -107,9 +107,9 @@ The implementation of ~Search_Lower_Bound~ is defined as follows:
   	 pragma Loop_Invariant
   	   (if Right /= A'Last + 1 then
   	      Lower_Bound (A (Right .. A'Last), V));
-  
+
         end loop;
-  
+
         return Result;
      end if;
   end Search_Lower_Bound;

--- a/binary-search/Search_Upper_Bound.org
+++ b/binary-search/Search_Upper_Bound.org
@@ -10,7 +10,7 @@ to the ~Search_Lower_Bound~ algorithm. Its signature can be
 expressed as:
 
 #+BEGIN_SRC ada
-  function Search_Upper_Bound (A : T_arr; V : T) return Option
+  function Search_Upper_Bound (A : T_arr; V : T) return Option;
 #+END_SRC
 
 ** Working principle
@@ -81,13 +81,13 @@ The implementation of ~Search_Upper_Bound~ is defined as follows:
         Result := (Exists => True, Value => A'Last + 1);
         while (Left < Result.Value) loop
   	 Middle := Left + (Result.Value - Left) / 2;
-  
+
   	 if A (Middle) <= Val then
   	    Left := Middle + 1;
   	 else
   	    Result.Value := Middle;
   	 end if;
-  
+
   	 pragma Loop_Variant (Decreases => Result.Value - Left);
   	 pragma Loop_Invariant (A'First <= Left);
   	 pragma Loop_Invariant (Left <= Result.Value);
@@ -101,7 +101,7 @@ The implementation of ~Search_Upper_Bound~ is defined as follows:
         end loop;
         return Result;
      end if;
-  
+
   end Search_Upper_Bound;
 #+END_SRC
 
@@ -110,7 +110,7 @@ is narrowed down. Again, note that the ~middle~ is calculated to
 avoid potential overflows.
 
 The loop variant is ~Result.Value - Left~ which decreases at each
-step. It is needed as we use a ~For~ loop here. The loop
+step. It is needed as we use a ~for~ loop here. The loop
 invariants express
 
 - that ~Result.Value~ and ~Left~ are in the correct range and

--- a/maxmin/Max_Element.org
+++ b/maxmin/Max_Element.org
@@ -8,7 +8,7 @@ The ~Max_Element~ algorithm finds the index of the maximum value of
 an array. Its signature can be expressed as:
 
 #+BEGIN_SRC ada
-  function Max_Element (A : T_Arr) return Option
+  function Max_Element (A : T_Arr) return Option;
 #+END_SRC
 
 ~Max_Element~ will return the first index where the maximum is
@@ -74,7 +74,7 @@ such an element, we replace ~Result.Value~ by its index.
   	 if A (Result.Value) < A (I) then
   	    Result.Value := I;
   	 end if;
-  
+
   	 pragma Loop_Invariant (A'First <= Result.Value);
   	 pragma Loop_Invariant (A'Last >= Result.Value);
   	 pragma Loop_Invariant
@@ -83,13 +83,13 @@ such an element, we replace ~Result.Value~ by its index.
   	   (for all K in A'First .. Result.Value - 1 =>
   	      A (K) < A (Result.Value));
         end loop;
-  
+
         return Result;
      end if;
   end Max_Element;
 #+END_SRC
 
-As usual with ~For~ loops in SPARK, no variant is needed. The loop
+As usual with ~for~ loops in SPARK, no variant is needed. The loop
 invariants specify that:
 
 1. the ~Result.Value~ value is in range ~A'First .. A'Last~.
@@ -128,7 +128,7 @@ index is less than the maximum value.
 These two ghost functions are only wrappers for expressions used
 previously in the specification of ~Max_Element~. Notice that we
 use an array as parameter without asking for start and end
-indexesin ~Strict_Upper_Bound~, therefore we will use slices when
+indexes in ~Strict_Upper_Bound~, therefore we will use slices when
 using this predicate.
 
 *** Specification of Max_Element
@@ -169,7 +169,7 @@ The implementation is almost the same as before:
   	 if A (Result.Value) < A (I) then
   	    Result.Value := I;
   	 end if;
-  
+
   	 pragma Loop_Invariant (A'First <= Result.Value);
   	 pragma Loop_Invariant (Result.Value <= A'Last);
   	 pragma Loop_Invariant
@@ -179,7 +179,7 @@ The implementation is almost the same as before:
   	      Strict_Upper_Bound
   		(A (A'First .. Result.Value - 1), A (Result.Value)));
         end loop;
-  
+
         return Result;
      end if;
   end Max_Element;

--- a/maxmin/Max_Seq.org
+++ b/maxmin/Max_Seq.org
@@ -10,7 +10,7 @@ array.
 Its signature can be defined as:
 
 #+BEGIN_SRC ada
-  function Max_Seq (A : T_Arr) return T
+  function Max_Seq (A : T_Arr) return T;
 #+END_SRC
 
 This algorithm will use the previous ~Max_Element~ algorithm,

--- a/maxmin/Min_Element.org
+++ b/maxmin/Min_Element.org
@@ -8,7 +8,7 @@ The ~Min_Element~ algorithm searches the minimum in a general sequence.
 Its signature can be expressed as:
 
 #+BEGIN_SRC ada
-  function Min_Element(A : T_arr) return Option
+  function Min_Element(A : T_arr) return Option;
 #+END_SRC
 
 ~Min_Element~ will return an option containing the first index ~I~
@@ -67,14 +67,14 @@ The specification of ~Min_Element~ can be expressed as follows:
   	    A (Min_Element'Result.Value))));
 #+END_SRC
 
-Here, the post conditions are expressed through 2 contract cases:
+Here, the postconditions are expressed through 2 contract cases:
 
 - if ~A~ is empty then an "empty" ~Option~ is returned
 - else there is a valid index returned and
   1. the result is a lower bound for the values in ~A~
   2. for all value ~V~ of ~A~ found at an index stricly lower than
      ~Result.Value~ then ~V > A(Result.Value)~. This expresses the
-     fact that rhe result is indeed the first index containing the
+     fact that the result is indeed the first index containing the
      minimum element of ~A~.
 
 ** Implementation of Min_Element
@@ -90,12 +90,12 @@ Here, the post conditions are expressed through 2 contract cases:
         return Result;
      else
         Result := (Exists => True, Value => A'First);
-  
+
         for I in A'First .. A'Last loop
   	 if A (I) < A (Result.Value) then
   	    Result.Value := I;
   	 end if;
-  
+
   	 pragma Loop_Invariant (Result.Value in A'First .. A'Last);
   	 pragma Loop_Invariant
   	   (Lower_Bound (A (A'First .. I), A (Result.Value)));
@@ -103,13 +103,13 @@ Here, the post conditions are expressed through 2 contract cases:
   	   ((if Result.Value > A'First then
   	       Strict_Lower_Bound
   		 (A (A'First .. Result.Value - 1), A (Result.Value))));
-  
+
         end loop;
-  
+
         return Result;
-  
+
      end if;
-  
+
   end Min_Element;
 #+END_SRC
 

--- a/mutating/Copy.org
+++ b/mutating/Copy.org
@@ -8,10 +8,10 @@ The ~Copy~ procedure copies the content of an array into another
 array. Its signature is the following:
 
 #+BEGIN_SRC ada
-  procedure Copy (A : T_Arr; B : in out T_Arr)
+  procedure Copy (A : T_Arr; B : in out T_Arr);
 #+END_SRC
 
-The usefulness of this procedure could be doubted in ADA, since the
+The usefulness of this procedure could be doubted in Ada, since the
 simple command ~A := B~ achieves the same goal for arrays with same
 length. The purpose of this document being to prove classic
 algorithms defined in [[https://github.com/fraunhoferfokus/acsl-by-example][ACSL by Example]] for the C language, we choose
@@ -49,9 +49,9 @@ A possible implementation for ~Copy~ is the following:
   	 K : Positive := B'First + (J - A'First);
         begin
   	 B (K) := A (J);
-  
+
   	 pragma Loop_Invariant (A (A'First .. J) = B (B'First .. K));
-  
+
         end;
      end loop;
   end Copy;

--- a/mutating/Fill.org
+++ b/mutating/Fill.org
@@ -8,7 +8,7 @@ The ~Fill~ algorithm initializes an array with a particular
 value. Here is its signature:
 
 #+BEGIN_SRC ada
-  procedure Fill (A : in out T_Arr; Val : T)
+  procedure Fill (A : in out T_Arr; Val : T);
 #+END_SRC
 
 ~A~ needs of course to be passed as a ~out~ parameter as it will be
@@ -41,7 +41,7 @@ The implementation of ~Fill~ is the following:
   begin
      for I in A'Range loop
         A (I) := Val;
-  
+
         pragma Loop_Invariant
   	(Constant_Range_From_Location (A, Val, A'First, I - A'First + 1));
      end loop;

--- a/mutating/Random_Shuffle.org
+++ b/mutating/Random_Shuffle.org
@@ -81,16 +81,15 @@ implementation is defined as follows:
 
 #+BEGIN_SRC ada
   procedure Random_Shuffle (A : in out T_Arr) is
-        J : Positive;
-     begin
-  
-        for I in A'Range loop
-  	 J := Random_Number(A'First, I);
-  	 Swap(A(I),A(J));
-  
-  	 pragma Loop_Invariant(Multiset_Unchanged(A,A'Loop_Entry));
-  
-        end loop;
+     J : Positive;
+  begin
+     for I in A'Range loop
+        J := Random_Number(A'First, I);
+  	Swap(A(I),A(J));
+
+  	pragma Loop_Invariant(Multiset_Unchanged(A,A'Loop_Entry));
+
+      end loop;
   end Random_Shuffle;
 #+END_SRC
 
@@ -146,11 +145,11 @@ The implementation (without SPARK annotations) is quite straightforward:
 #+BEGIN_SRC ada
   function Swap_Array (A : T_Arr; I : Positive;
   		     J : Positive) return T_Arr is
-        Temp : T := A(I);
-     begin
-        A(I) := A(J);
-        A(J) := Temp;
-     end Swap_Array;
+     Temp : T := A(I);
+  begin
+     A(I) := A(J);
+     A(J) := Temp;
+  end Swap_Array;
 #+END_SRC
 
 With this current implementation, the desired result is
@@ -230,7 +229,7 @@ The proof of the lemma is given in its implementation:
      if A'Length = 0 then
         return;
      end if;
-  
+
      if J = A'Last then
         Occ_Equal (Tmp, Remove_Last (B), E);
      else
@@ -329,14 +328,14 @@ procedure to ~Swap_Array~:
   is
      A_Init : T_Arr (A'Range) := A;
      Temp   : T               := A (J);
-  
+
      -- ghost variable
-  
+
      A_After_First : T_Arr (A'Range) with
         Ghost;
-  
+
         -- ghost procedure
-  
+
      procedure Prove_Perm with
         Ghost,
         Pre => J in A'Range and then K in A'Range
@@ -352,18 +351,18 @@ procedure to ~Swap_Array~:
   	   (for all F in T'First .. V => Occ (A_Init, F) = Occ (A, F));
         end loop;
      end Prove_Perm;
-  
+
   begin
      A (J)         := A (K);
      A_After_First := A; -- ghost code
-  
+
      pragma Assert (Is_Set (A_Init, J, A_Init (K), A_After_First));
-  
+
      A (K) := Temp;
-  
+
      pragma Assert (Is_Set (A_After_First, K, A_Init (J), A));
      Prove_Perm; -- ghost code
-  
+
   end Swap_Array;
 #+END_SRC
 
@@ -376,13 +375,13 @@ We can now give somewhat condensed and simple implementation of
   procedure Random_Shuffle (A : in out T_Arr) is
      J : Positive;
   begin
-  
+
      for I in A'Range loop
         J := Random_Number (A'First, I);
-  
+
         Swap_Array (A, I, J);
         pragma Loop_Invariant (Multiset_Unchanged (A, A'Loop_Entry));
-  
+
      end loop;
   end Random_Shuffle;
 #+END_SRC
@@ -424,14 +423,14 @@ specification and implementation of ~Random_Number~ are:
      Last  : Positive)
      return Positive
   is
-  
+
      subtype Rng is Positive range First .. Last;
      package Alea is new Ada.Numerics.Discrete_Random (Rng);
      use Alea;
-  
+
      Rnd_Gen : Generator;
      Result  : Integer;
-  
+
   begin
      Reset (Rnd_Gen);
      Result := Random (Rnd_Gen);
@@ -440,9 +439,9 @@ specification and implementation of ~Random_Number~ are:
      elsif Result > Last then
         Result := Last;
      end if;
-  
+
      return Result;
-  
+
   end Random_Number;
 #+END_SRC
 

--- a/mutating/Reverse_Copy.org
+++ b/mutating/Reverse_Copy.org
@@ -9,7 +9,7 @@ given array ~A~ in another array ~B~ without modifying ~A~. Its
 signature is:
 
 #+BEGIN_SRC ada
-  procedure Reverse_Copy (A : T_Arr; B : in out T_Arr)
+  procedure Reverse_Copy (A : T_Arr; B : in out T_Arr);
 #+END_SRC
 
 ** The Is_Reversed predicate
@@ -61,11 +61,11 @@ reverse order of those of ~B~.
   begin
      for J in B'Range loop
         B (J) := A (A'Last - (J - B'First));
-  
+
         pragma Loop_Invariant
   	(Is_Reversed
   	   (B (B'First .. J), A (A'Last - (J - B'First) .. A'Last)));
-  
+
      end loop;
   end Reverse_Copy;
 #+END_SRC

--- a/mutating/Reverse_In_Place.org
+++ b/mutating/Reverse_In_Place.org
@@ -9,7 +9,7 @@ The ~Reverse_In_Place~ algorithm aims to achieve the same goal as
 modifying it, instead of copying it. Its signature reads:
 
 #+BEGIN_SRC ada
-  procedure Reverse_In_Place (A : in out T_Arr)
+  procedure Reverse_In_Place (A : in out T_Arr);
 #+END_SRC
 
 ** Specification of Reverse_In_Place
@@ -39,16 +39,16 @@ defined earlier:
   	(if A'Length mod 2 = 0 then 0 else 1)
         else 1);
   begin
-  
+
      if A'Length <= 1 then
         return;
      end if;
-  
+
      for J in 0 .. Half - A'First loop
-  
+
         pragma Assert (A'First + J /= A'Last - J);
         Swap (A (A'First + J), A (A'Last - J));
-  
+
         pragma Loop_Variant (Increases => J);
         pragma Loop_Invariant
   	(A (A'First + J + 1 .. A'Last - (J + 1)) =
@@ -61,9 +61,9 @@ defined earlier:
   	(Is_Reversed
   	   (A'Loop_Entry (A'First .. A'First + J),
   	    A (A'Last - J .. A'Last)));
-  
+
      end loop;
-  
+
   end Reverse_In_Place;
 #+END_SRC
 
@@ -106,16 +106,16 @@ the implementation of ~Reverse_In_Place~ by removing the call to
         else 1);
      T1 : T;
   begin
-  
+
      if A'Length <= 1 then
         return;
      end if;
-  
+
      for J in 0 .. Half - A'First loop
         T1              := A (A'First + J);
         A (A'First + J) := A (A'Last - J);
         A (A'Last - J)  := T1;
-  
+
         pragma Loop_Variant (Increases => J);
         pragma Loop_Invariant
   	(A (A'First + J + 1 .. A'Last - (J + 1)) =
@@ -128,9 +128,9 @@ the implementation of ~Reverse_In_Place~ by removing the call to
   	(Is_Reversed
   	   (A'Loop_Entry (A'First .. A'First + J),
   	    A (A'Last - J .. A'Last)));
-  
+
      end loop;
-  
+
   end Reverse_In_Place;
 #+END_SRC
 

--- a/mutating/Swap.org
+++ b/mutating/Swap.org
@@ -6,19 +6,21 @@
 
 The ~Swap~ algorithm exchanges the contents of two variables. Its
 signature can be expressed as: ~procedure Swap (P : in out T; Q :
-   in out T)~
+   in out T);~
 
 ** Specification of Swap
 
 The specification of ~Swap~ is the following:
 
 #+BEGIN_SRC ada
-  is
-    procedure Swap
+  procedure Swap
+    (P : in out T;
+     Q : in out T) with
+     Post => P = Q'Old and then Q = P'Old;
 #+END_SRC
 
 The postcondition expresses the fact that the two variables have
-actually been exchanged, using the ~'Old~ attribute available in
+actually been exchanged, using the '~Old~ attribute available in
 SPARK. This attribute stores the state of the variables *before*
 the execution of the procedure.
 

--- a/mutating/Swap_Ranges.org
+++ b/mutating/Swap_Ranges.org
@@ -7,11 +7,11 @@
 The ~Swap_Ranges~ algorithm exchanges the contents of two arrays.
 Its signature is the following:
 
-~procedure Swap_Ranges (A : in out T_Arr; B: in out T_Arr)~
+~procedure Swap_Ranges (A : in out T_Arr; B: in out T_Arr);~
 
 ** Specification of Swap_Ranges
 
-The specification of ~swap_ranges~ is the following:
+The specification of ~Swap_Ranges~ is the following:
 
 #+BEGIN_SRC ada
   procedure Swap_Ranges
@@ -34,10 +34,10 @@ for arrays, the assertion are easy to write.
      B : in out T_Arr)
   is
   begin
-  
+
      for J in 0 .. A'Length - 1 loop
         Swap (A (A'First + J), B (B'First + J));
-  
+
         pragma Loop_Invariant
   	(B'Loop_Entry (B'First .. B'First + J) =
   	 A (A'First .. A'First + J));
@@ -78,13 +78,13 @@ least to our point of view) implementation of ~Swap_Ranges~:
      B : in out T_Arr)
   is
   begin
-  
+
      for J in A'Range loop
         declare
   	 K : Positive := B'First + (J - A'First);
         begin
   	 Swap (A (J), B (K));
-  
+
   	 pragma Loop_Invariant
   	   (B'Loop_Entry (B'First .. K) = A (A'First .. J));
   	 pragma Loop_Invariant
@@ -96,7 +96,7 @@ least to our point of view) implementation of ~Swap_Ranges~:
   	 pragma Loop_Invariant
   	   (if J < A'Last then
   	      A'Loop_Entry (J + 1 .. A'Last) = A (J + 1 .. A'Last));
-  
+
         end;
      end loop;
   end Swap_Ranges;
@@ -104,6 +104,6 @@ least to our point of view) implementation of ~Swap_Ranges~:
 
 In this implementation, we will not use an offset as loop
 variable, but range over ~A'Range~. A local variable is defined
-for readibility to define the corresponding index for ~B~.
+for readability to define the corresponding index for ~B~.
 
 Again, everything is proved using ~GNATprove~.

--- a/non-mutating/Adjacent_Find.org
+++ b/non-mutating/Adjacent_Find.org
@@ -8,7 +8,7 @@ The ~Adjacent_Find~ algorithm is another finding algorithm. Its
 signature is the following:
 
 #+BEGIN_SRC ada
-  function Adjacent_Find (A : T_Arr) return Option
+  function Adjacent_Find (A : T_Arr) return Option;
 #+END_SRC
 
 Given an array ~A~, ~Adjacent_Find~ will either return:
@@ -79,19 +79,19 @@ for two consecutive elements that are equal is defined as follows:
      if A'Length <= 1 then
         return Result;
      end if;
-  
+
      for I in A'First .. A'Last - 1 loop
         if A (I) = A (I + 1) then
   	 Result := (Exists => True, Value => I);
-  
+
   	 return Result;
         end if;
-  
+
         pragma Loop_Invariant
   	(not Has_Equal_Neighbors (A (A'First .. I + 1)));
         pragma Loop_Invariant (not Result.Exists);
      end loop;
-  
+
      return Result;
   end Adjacent_Find;
 #+END_SRC

--- a/non-mutating/Count.org
+++ b/non-mutating/Count.org
@@ -8,7 +8,7 @@ The ~Count~ algorithm counts the number of occurrences of a value
 ~Val~ in an array ~A~. Its signature can be expressed as:
 
 #+BEGIN_SRC ada
-  function Count (A : T_Arr; Val : T) return Natural
+  function Count (A : T_Arr; Val : T) return Natural;
 #+END_SRC
 
 ** The predicate Occ
@@ -21,7 +21,7 @@ serve as a mathematical specification for ~Count~.
 array (see [[http://docs.adacore.com/spark2014-docs/html/ug/GNATprove_by_example/manual_proof.html#manual-proof-using-ghost-code][SPARK 2014 user guide chapter on manual proof with
 ghost code]] for a similar and more detailed example). We first
 define a recursive function ~Occ_Def~ which will be used in ~Occ~
-as *~GNATprove~ only introduces axioms for postconditions of
+as *GNATprove only introduces axioms for postconditions of
 non-recursive functions*.
 
 #+BEGIN_SRC ada
@@ -30,7 +30,7 @@ non-recursive functions*.
      return T_Arr is (A (A'First .. A'Last - 1)) with
      Pre => A'Length > 0,
      Ghost;
-  
+
   function Occ_Def
     (A   : T_Arr;
      Val : T)
@@ -105,11 +105,11 @@ The implementation of ~Count~ is the following:
         if A (I) = Val then
   	 Result := Result + 1;
         end if;
-  
+
         pragma Loop_Invariant (Result <= A'Length);
         pragma Loop_Invariant (Result = Occ (A (A'First .. I), Val));
      end loop;
-  
+
      return Result;
   end Count;
 #+END_SRC

--- a/non-mutating/Equal_Mismatch.org
+++ b/non-mutating/Equal_Mismatch.org
@@ -8,14 +8,14 @@
 signatures are the following:
 
 #+BEGIN_SRC ada
-  function Equal (A : T_Arr; B : T_Arr) return Boolean
-  function Mismatch (A : T_Arr; B : T_Arr) return Option
+  function Equal (A : T_Arr; B : T_Arr) return Boolean;
+  function Mismatch (A : T_Arr; B : T_Arr) return Option;
 #+END_SRC
 
 ~Equal (A, B)~ returns ~True~ if ~A~ and ~B~ have the same length
 and elements of ~A~ and ~B~ are equal when traversing ~A~ and ~B~
 in the same order. ~Mismatch~ is not simply the negation of
-~Equal~: it returns the least valid index ~J~ of ~A~ such that ~A
+~Equal~: it returns the smallest valid index ~J~ of ~A~ such that ~A
    (J)~ differs from ~B (J)~ (an ~Option~ is used to consider the case
 where ~A~ and ~B~ are identical).
 
@@ -45,9 +45,12 @@ used):
 
 #+BEGIN_SRC ada
   function Equal_Ranges
-    (A : T_Arr;
-     B : T_Arr)
-     return Boolean is (A = B);
+    (A      : T_Arr;
+     B      : T_Arr;
+     Offset : Natural)
+     return Boolean is
+    (A (A'First .. A'First + Offset) = B (B'First .. B'First + Offset)) with
+     Pre => Offset < A'Length and then Offset < B'Length;
 #+END_SRC
 
 We need to add a [[http://docs.adacore.com/spark2014-docs/html/ug/en/source/subprogram_contracts.html#preconditions][precondition]] to exclude invalid ~Offset~
@@ -104,14 +107,14 @@ The implementation of ~Mismatch~ is the following:
      for I in 0 .. A'Length - 1 loop
         if A (A'First + I) /= B (B'First + I) then
   	 Result := (Exists => True, Value => I);
-  
+
   	 return Result;
         end if;
-  
+
         pragma Loop_Invariant (Equal_Ranges (A, B, I));
         pragma Loop_Invariant (not Result.Exists);
      end loop;
-  
+
      return Result;
   end Mismatch;
 #+END_SRC

--- a/non-mutating/Find.org
+++ b/non-mutating/Find.org
@@ -9,21 +9,21 @@ The array will be represented by the following types:
 
 #+BEGIN_SRC ada
   type T is new Integer;
-  
+
   type T_Arr is array (Positive range <>) of T;
 #+END_SRC
 
-~T_Arr~ is an array of integers, with indexes ranging the positive
+~T_Arr~ is an array of integers, with indexes ranging over positive
 integers. We will use this type in the functions needing an array.
 
 Mimicking the C++ standard library, the signature of ~Find~ can be
 defined as follows:
 
 #+BEGIN_SRC ada
-  function Find (A : T_Arr; Val : T) return Positive
+  function Find (A : T_Arr; Val : T) return Positive;
 #+END_SRC
 
-~Find~ will return the *least valid* index ~I~ of ~A~ such that ~A
+~Find~ will return the *smallest valid* index ~I~ of ~A~ such that ~A
    (I) = Val~. If no such index exists, ~Find~ returns the length of
 ~A~.
 
@@ -108,10 +108,10 @@ The implementation of ~Find~ is straightforward:
         if A (I) = Val then
   	 return I;
         end if;
-  
+
         pragma Loop_Invariant (for all J in A'First .. I => A (J) /= Val);
      end loop;
-  
+
      return A'Last + 1;
   end Find;
 #+END_SRC
@@ -119,13 +119,13 @@ The implementation of ~Find~ is straightforward:
 - the implementation is classic: we range over ~A~ indexes trying
   to find an element equal to ~Val~. If we find such an element,
   its index is returned, which guarantees that this will be the
-  least valid index.
+  smallest valid index.
 - in order to prove the postconditions of ~Find~, we must add a
-  *loop invariant*. At each loop turn, we can assert after the
+  *loop invariant*. At each loop iteration, we can assert after the
   conditional that each traversed element differs from
   ~Val~. This will be useful to prove that the returned value is
-  the least valid index of ~A~ such that the corresponding
-  element is equal to ~A~ and this is the invariant we have
+  the smallest valid index of ~A~ such that the corresponding
+  element is equal to ~Val~ and this is the invariant we have
   chosen.
 
   You can try to remove the invariant: in this case, some
@@ -154,7 +154,7 @@ We can provide a less naive version of ~Find~ by
 - factorizing specification in a *ghost* function ~Has_Value~ that
   specifies that a value occurs in an array. This ghost function
   can be reused in other specifications. [[http://docs.adacore.com/spark2014-docs/html/ug/en/source/specification_features.html#ghost-code][Ghost functions]] are
-  functions that are discared during compilation but can be used
+  functions that are discarded during compilation but can be used
   for specification. They can be used like *predicates* in ACSL.
 - solving the range and overflow errors by encapsulating the
   result of the function in an "option" type
@@ -244,14 +244,14 @@ except the use of the ~Option~ type:
      for I in A'Range loop
         if A (I) = Val then
   	 Result := (Exists => True, Value => I);
-  
+
   	 return Result;
         end if;
-  
+
         pragma Loop_Invariant (not Has_Value (A (A'First .. I), Val));
         pragma Loop_Invariant (not Result.Exists);
      end loop;
-  
+
      return Result;
   end Find;
 #+END_SRC

--- a/non-mutating/Find_End.org
+++ b/non-mutating/Find_End.org
@@ -8,10 +8,10 @@ The ~Find_End~ algorithm finds the last occurence of a given
 subsquence in a given array. Its signature can be expressed as:
 
 #+BEGIN_SRC ada
-  function Find_End (A : T_Arr; B : T_Arr) return Option
+  function Find_End (A : T_Arr; B : T_Arr) return Option;
 #+END_SRC
 
-~Find_End~ will return an option containing the *last valid* index
+~Find_End~ will return an option containing the greatest valid index
 ~I~ of ~A~ such that ~A (I .. I + B'Length -1 ) = B~ if it exists.
 
 The ~Find_End~ function is quite similar to the [[Search.org][Search]] function,
@@ -73,14 +73,14 @@ The specification of ~Find_End~ is as follows:
      if (A'Length < B'Length or else B'Length = 0) then
         return Result;
      end if;
-  
+
      for J in A'First .. A'Last - B'Length + 1 loop
         if A (J .. J - 1 + B'Length) = B then
   	 Result := (Exists => True, Value => J);
-  
+
   	 pragma Assert (J - 1 + B'Length = Last (J, B));
         end if;
-  
+
         pragma Loop_Invariant
   	(if Result.Exists then
   	   Has_Subrange (A, B)
@@ -91,11 +91,11 @@ The specification of ~Find_End~ is as follows:
   	      not Has_Subrange
   		(A (Result.Value + 1 .. J - 1 + B'Length), B))
   	 else not Has_Subrange (A (A'First .. J - 1 + B'Length), B));
-  
+
      end loop;
-  
+
      return Result;
-  
+
   end Find_End;
 #+END_SRC
 

--- a/non-mutating/Find_First_Of.org
+++ b/non-mutating/Find_First_Of.org
@@ -5,14 +5,14 @@
 * The Find_First_Of algorithm
 
 The ~Find_First_Of~ algorithm is related to ~Find~: given an array
-~A~ and an array ~B~, it will return the least valid index of ~A~
+~A~ and an array ~B~, it will return the smallest valid index of ~A~
 such that the element at this position also occurs in ~B~. The
 ~Option~ type is again used to encapsulate the result.
 
 The signature of ~Find_First_Of~ is the following:
 
 #+BEGIN_SRC ada
-  function Find_First_Of (A : T_Arr; B : T_Arr) return Option
+  function Find_First_Of (A : T_Arr; B : T_Arr) return Option;
 #+END_SRC
 
 ** The predicate Has_Value_Of
@@ -78,14 +78,14 @@ The implementation of Find_First_Of is the following:
      for I in A'Range loop
         if Find (B, A (I)).Exists then
   	 Result := (Exists => True, Value => I);
-  
+
   	 return Result;
         end if;
-  
+
         pragma Loop_Invariant (not Has_Value_Of (A (A'First .. I), B));
         pragma Loop_Invariant (not Result.Exists);
      end loop;
-  
+
      return Result;
   end Find_First_Of;
 #+END_SRC

--- a/non-mutating/Search.org
+++ b/non-mutating/Search.org
@@ -8,10 +8,10 @@ The ~Search~ algorithm finds a subsequence in an array identical
 to a given sequence. Its signature can be defined as:
 
 #+BEGIN_SRC ada
-  function Search (A : T_Arr; B : T_Arr) return Option
+  function Search (A : T_Arr; B : T_Arr) return Option;
 #+END_SRC
 
-~Search~ will return an option containing the *first valid* index
+~Search~ will return an option containing the smallest valid index
 ~J~ of ~A~ such that ~A (J .. J + B'Length - 1) = B~ if it exists.
 
 ** A first version of Search without ghost functions for specification
@@ -82,19 +82,19 @@ A specification of ~Search~ can be written as follows:
      if (A'Length < B'Length or else B'Length = 0) then
         return Result;
      end if;
-  
+
      for I in A'First .. A'Last + 1 - B'Length loop
         if A (I .. I - 1 + B'Length) = B then
   	 Result := (Exists => True, Value => I);
-  
+
   	 return Result;
         end if;
-  
+
         pragma Loop_Invariant
   	(for all J in A'First .. I => A (J .. J - 1 + B'Length) /= B);
         pragma Loop_Invariant (not Result.Exists);
      end loop;
-  
+
      return Result;
   end Search;
 #+END_SRC
@@ -203,19 +203,19 @@ the use of ~Has_Subrange~:
      if (A'Length < B'Length or else B'Length = 0) then
         return Result;
      end if;
-  
+
      for I in A'First .. A'Last + 1 - B'Length loop
         if A (I .. I - 1 + B'Length) = B then
   	 Result := (Exists => True, Value => I);
-  
+
   	 return Result;
         end if;
-  
+
         pragma Loop_Invariant
   	((not Has_Subrange (A (A'First .. I + B'Length - 1), B)));
         pragma Loop_Invariant (not Result.Exists);
      end loop;
-  
+
      return Result;
   end Search;
 #+END_SRC
@@ -229,7 +229,7 @@ implementation.
 
 An usual trick to help SMT solvers is to hide the unnecessary
 quantifiers in auxiliary subprograms (this has been suggested by
-Yannick Moy of Adacore). A previous version of ~Search~ redefines
+Yannick Moy of AdaCore). A previous version of ~Search~ redefines
 the ~Has_Subrange~ function by using two intermediate functions
 allowing to hide the quantifiers: one function to express that a
 subrange of ~A~ is equal to ~B~ starting from a particular index
@@ -240,7 +240,7 @@ to bound the subrange with a lower index and the other one with an
 upper index). See the ~GPL2017~ branch of Spark by Example
 repository for this implementation.
 
-Claire Dross from Adacore suggested that the provers have
+Claire Dross from AdaCore suggested that the provers have
 difficulties with the slices and particularly the expression ~J -
     1 + B'Length~ that is used to qualify the last index of a slice of
 ~A~ starting from ~J~ and with a length equal to ~B~
@@ -314,22 +314,22 @@ The implementation of ~Search~ is the following:
      Result : Option := (Exists => False);
   begin
      if (A'Length < B'Length or else B'Length = 0) then
-  
+
         return Result;
      end if;
-  
+
      for J in A'First .. A'Last + 1 - B'Length loop
         if A (J .. J - 1 + B'Length) = B then
   	 Result := (Exists => True, Value => J);
-  
+
   	 return Result;
         end if;
-  
+
         pragma Loop_Invariant
   	(for all K in A'First .. J => A (K .. Last (K, B)) /= B);
         pragma Loop_Invariant (not Result.Exists);
      end loop;
-  
+
      return Result;
   end Search;
 #+END_SRC

--- a/non-mutating/Search_N.org
+++ b/non-mutating/Search_N.org
@@ -16,7 +16,7 @@ As usual, we will use an ~Option~ to encapsulate the result.
 
 ** The Constant_Range_From_Location and Has_Constant_Subrange predicates
 
-Like usual, we define predicates to express more easily the
+As usual, we define predicates to express more easily the
 specification of ~Search_N~.
 
 First, we define a ~Constant_Range_From_Location~ ghost function to
@@ -110,16 +110,16 @@ The implementation of ~Search_N~ is the following:
      if A'Length < N then
         return Result;
      end if;
-  
+
      for I in A'Range loop
         if A (I) /= Val then
   	 Start := I + 1;
         elsif I + 1 - Start = N then
   	 Result := (Exists => True, Value => Start);
-  
+
   	 return Result;
         end if;
-  
+
         pragma Loop_Invariant (not Result.Exists);
         pragma Loop_Invariant (Start in A'First .. I + 1);
         pragma Loop_Invariant
@@ -129,9 +129,9 @@ The implementation of ~Search_N~ is the following:
   	(not Has_Constant_Subrange (A (A'First .. I), Val, N));
         pragma Loop_Invariant (if Start > A'First then A (Start - 1) /= Val);
      end loop;
-  
+
      return Result;
-  
+
   end Search_N;
 #+END_SRC
 

--- a/non-mutating/adjacent_find_p.ads
+++ b/non-mutating/adjacent_find_p.ads
@@ -16,7 +16,7 @@ package Adjacent_Find_P with
          (A (Adjacent_Find'Result.Value) = A (Adjacent_Find'Result.Value + 1))
          and then
          (not Has_Equal_Neighbors
-            (A (A'First .. Adjacent_Find'Result.Value - 1))),
+            (A (A'First .. Adjacent_Find'Result.Value))),
        others => Adjacent_Find'Result.Exists = False);
 
 end Adjacent_Find_P;

--- a/non-mutating/mismatch_p.ads
+++ b/non-mutating/mismatch_p.ads
@@ -13,7 +13,7 @@ package Mismatch_P with
       return Option with
       Pre            => A'Length = B'Length,
       Contract_Cases =>
-      (Equal_Ranges (A, B (B'First .. B'First - 1 + A'Length)) =>
+      (Equal_Ranges (A, B) =>
          not Mismatch'Result.Exists,
        others =>
          Mismatch'Result.Exists

--- a/non-mutating/naive_find_contract_pb.ads
+++ b/non-mutating/naive_find_contract_pb.ads
@@ -10,6 +10,7 @@ package Naive_Find_Contract_Pb with
      (A   : T_Arr;
       Val : T)
       return Positive with
+      Import,
       Post =>
       (Find'Result <= A'Last + 1
        and then (for all I in A'First .. Find'Result - 1 => A (I) /= Val)),

--- a/non-mutating/search_n_p.ads
+++ b/non-mutating/search_n_p.ads
@@ -22,7 +22,7 @@ package Search_N_P with
          and then
          (if Search_N'Result.Value > A'First then
             not Has_Constant_Subrange
-              (A (A'First .. Search_N'Result.Value - 1), Val, N)),
+              (A (A'First .. Search_N'Result.Value + N - 2), Val, N)),
        others => not Search_N'Result.Exists);
 
 end Search_N_P;

--- a/numeric/Accumulate.org
+++ b/numeric/Accumulate.org
@@ -8,7 +8,7 @@ The ~Accumulate~ algorithm will compute the sum of the elements of
 an array. Its signature reads:
 
 #+BEGIN_SRC ada
-  function Accumulate (A : T_Arr; Init : T) return T
+  function Accumulate (A : T_Arr; Init : T) return T;
 #+END_SRC
 
 The algorithm will return ~Init + A (A'First) + A (A'First+1) +
@@ -80,14 +80,14 @@ An implementation satifying our specification is the following
      Result : T := Init;
   begin
      for I in A'Range loop
-  
+
         pragma Assert (Acc_Def (A (A'First .. I), Init) in T);
         Result := Result + A (I);
         pragma Loop_Invariant (Result = Acc_Def (A (A'First .. I), Init));
-  
+
      end loop;
      return Result;
-  
+
   end Accumulate_Naive;
 #+END_SRC
 
@@ -117,7 +117,7 @@ to avoid any potential overflow in *any part of the code*.
 ** A correct version of Accumulate
 
 As mentionned before we need to take care of the overflows in
-~Acc_Def_Rec~. Thanks to Claire Dross from Adacore for the
+~Acc_Def_Rec~. Thanks to Claire Dross from AdaCore for the
 following solution.
 
 *** Predicates used
@@ -240,9 +240,9 @@ An implementation deriving from the previous specification is:
         pragma Assert (Acc_Def (A, A'First, J, Init).OK);
         Result := Result + A (J);
         pragma Loop_Invariant (Result = Acc_Def (A, A'First, J, Init).Value);
-  
+
      end loop;
-  
+
      return Result;
   end Accumulate;
 #+END_SRC

--- a/numeric/Iota.org
+++ b/numeric/Iota.org
@@ -9,12 +9,12 @@ the initial value is specified by the user. Its signature is the
 following:
 
 #+BEGIN_SRC ada
-  procedure Iota (A : in out T_Arr ; Val : T)
+  procedure Iota (A : in out T_Arr ; Val : T);
 #+END_SRC
 
 For instance, let us suppose that ~A~ is an ~T~ array of size ~5~,
 then after a call ~Iota (A, 3)~, ~A~ will be ~(3, 4, 5, 6,
-   7)~. Notice that the incrementation step in not precised in the
+   7)~. Notice that the incrementation step in not specified in the
 function signature.
 
 ** The predicate Is_Iota
@@ -29,11 +29,10 @@ follows:
      Val : T)
      return Boolean is
     (for all I in A'Range => A (I) = Val + T (I - A'First)) with
-     Pre => Val + T (A'Length) <= T'Last;
+     Pre => Val + A'Length <= T'Last;
 #+END_SRC
 
-Notice that the precondition ensures that no overflow will happen
-(~T (A'Length)~ is the ~A'Length~ th value of type ~T~).
+Notice that the precondition ensures that no overflow will happen.
 
 ** Specification of Iota
 

--- a/numeric/Partial_Sum.org
+++ b/numeric/Partial_Sum.org
@@ -8,12 +8,13 @@ The ~Partial_Sum~ algorithm computes the consecutive partial
 sums of an array. Its signature reads:
 
 #+BEGIN_SRC ada
-  procedure Partial_Sum (A : T_Arr; B : in out T_Arr)
+  procedure Partial_Sum (A : T_Arr; B : in out T_Arr);
 #+END_SRC
 
 The result of the algorithm will be stored in ~B~, and for all ~K~
-in ~(0 .. A'Length - 1)~, ~B(B'First+K) = A (A'First) + A (A'First
-- 1) + .. + A(A'First + K)~. This can also be expressed with the
+in ~(0 .. A'Length - 1)~, ~B (B'First+K) = A (A'First) + A (A'First
+   .. - 1) + .. + A(A'First + K)~.
+This can also be expressed with the
 previously defined [[Accumulate.org][Accumulate]] algorithm: for all ~K~ in ~0
    .. A'Length-1~ then ~B (B'First + K) = Accumulate (A (A'First
    .. A'First + K), 0)~.
@@ -51,18 +52,18 @@ Given its specification, ~Partial_Sum~ can be implemented as follows:
   begin
      if A'Length > 0 then
         B (B'First) := A (A'First);
-  
+
         for J in 1 .. A'Length - 1 loop
-  
+
   	 pragma Assert (Acc_Def (A, A'First, A'First + J, 0).OK);
   	 pragma Assert
   	   (Add_No_Overflow (A (A'First + J), B (B'First + (J - 1))));
   	 B (B'First + J) := B (B'First + (J - 1)) + A (A'First + J);
-  
+
   	 pragma Loop_Invariant
   	   (for all K in 0 .. J =>
   	      B (B'First + K) = Acc_Def (A, A'First, A'First + K, 0).Value);
-  
+
         end loop;
      end if;
   end Partial_Sum;

--- a/numeric/iota_p.ads
+++ b/numeric/iota_p.ads
@@ -7,6 +7,6 @@ package Iota_P with
    procedure Iota
      (A   : in out T_Arr;
       Val :        T) with
-      Pre  => Val + T (A'Length) <= T'Last,
+      Pre  => Val + A'Length <= T'Last,
       Post => Is_Iota (A, Val);
 end Iota_P;

--- a/spark_by_example_shared.gpr
+++ b/spark_by_example_shared.gpr
@@ -2,8 +2,6 @@ project Spark_By_Example_Shared is
 
   for Source_Dirs use ();
 
-  for Object_Dir use "obj";
-
   package Compiler is
     for Default_Switches ("Ada") use ("-gnat12", "-gnato13", "-gnata");
   end Compiler;

--- a/spec/is_iota_p.ads
+++ b/spec/is_iota_p.ads
@@ -9,5 +9,5 @@ package Is_Iota_P with
       Val : T)
       return Boolean is
      (for all I in A'Range => A (I) = Val + T (I - A'First)) with
-      Pre => Val + T (A'Length) <= T'Last;
+      Pre => Val + A'Length <= T'Last;
 end Is_Iota_P;


### PR DESCRIPTION
binary-search/Binary_Search.org
binary-search/Search_Equal_Range.org
binary-search/Search_Lower_Bound.org
binary-search/Search_Upper_Bound.org
maxmin/Max_Element.org
maxmin/Max_Seq.org
maxmin/Min_Element.org
mutating/Copy.org
mutating/Fill.org
mutating/Random_Shuffle.org
mutating/Reverse_Copy.org
mutating/Reverse_In_Place.org
mutating/Swap.org
mutating/Swap_Ranges.org
non-mutating/Adjacent_Find.org
non-mutating/Count.org
non-mutating/Equal_Mismatch.org
non-mutating/Find.org
non-mutating/Find_End.org
non-mutating/Find_First_Of.org
non-mutating/Search.org
non-mutating/Search_N.org
numeric/Accumulate.org
numeric/Partial_Sum.org
  Add semicolon to signature.
  Automatically remove training whitespace.
  Fix minor typos.
  Fix indentation.
  Use "smallest" instead of "least", as "least valid index" means the index
  that is the least valid.

non-mutating/adjacent_find_p.ads
non-mutating/search_n_p.ads
  Strengthen the postcondition to have the most precise one.

non-mutating/mismatch_p.ads
  Rewrite slightly postcondition for better readability.

non-mutating/naive_find_contract_pb.ads
  Make function imported to avoid compilation error.

numeric/Iota.org
numeric/iota_p.ads
spec/is_iota_p.ads
  Remove useless conversions as A'Length is of universal integer type.

spark_by_example_shared.gpr
  Remove useless object dir as the shared project has no sources.
  This removes a warning, and an error when compiling without -p (to create
  the missing object dir).